### PR TITLE
fix(jar): evaluate fat jar platform exclusions lazily

### DIFF
--- a/src/main/kotlin/io/github/gciatto/kt/mpp/helpers/MultiPlatformHelperExtension.kt
+++ b/src/main/kotlin/io/github/gciatto/kt/mpp/helpers/MultiPlatformHelperExtension.kt
@@ -54,6 +54,7 @@ interface MultiPlatformHelperExtension {
     val fatJarPlatforms: DomainObjectSet<String>
     val fatJarClassifier: Property<String>
     val fatJarPlatformInclusions: DomainObjectSet<Pair<String, String>>
+    val fatJarDefaultExcludedPlatforms: DomainObjectSet<String>
     val fatJarEntryPoint: Property<String>
 
     fun fatJarPlatformInclude(

--- a/src/main/kotlin/io/github/gciatto/kt/mpp/helpers/MultiPlatformHelperExtensionImpl.kt
+++ b/src/main/kotlin/io/github/gciatto/kt/mpp/helpers/MultiPlatformHelperExtensionImpl.kt
@@ -187,6 +187,9 @@ internal open class MultiPlatformHelperExtensionImpl(
     override val fatJarPlatformInclusions: DomainObjectSet<Pair<String, String>> =
         project.objects.domainObjectSet(Pair::class.java) as DomainObjectSet<Pair<String, String>>
 
+    override val fatJarDefaultExcludedPlatforms: DomainObjectSet<String> =
+        objects.domainObjectSet(String::class.java)
+
     override val fatJarEntryPoint: Property<String> = propertyWithConvention()
 
     override fun populateArgumentsFromProperties() {

--- a/src/main/kotlin/io/github/gciatto/kt/mpp/jar/FatJarUtils.kt
+++ b/src/main/kotlin/io/github/gciatto/kt/mpp/jar/FatJarUtils.kt
@@ -41,13 +41,18 @@ internal fun Project.excludedPlatformsFor(platform: String): Set<String> =
 private fun defaultTaskName(platform: String?): String =
     "shadowJar" + platform?.let { "For${it.toPascalCase()}" }.orEmpty()
 
+// must not be called before the build script has been evaluated, as it reads mutable collections
 private fun Project.defaultExcludedPlatforms(platform: String?): Set<String> =
-    platform?.let { excludedPlatformsFor(it) }.orEmpty()
+    platform?.let { excludedPlatformsFor(it) }
+        ?: multiPlatformHelper.fatJarDefaultExcludedPlatforms.toSet()
 
 fun MultiPlatformHelperExtension.javaFxFatJars() {
     fatJarPlatforms.addAll(listOf("win", "linux", "mac", "mac-aarch64"))
     fatJarPlatformInclude("mac", "linux")
     fatJarPlatformInclude("mac-aarch64", "linux")
+    // the two macOS artifacts share the file names of their native libraries, hence the
+    // platform-less fat jar can only carry one of them
+    fatJarDefaultExcludedPlatforms.add("mac-aarch64")
 }
 
 fun Project.shadowJarTask(
@@ -55,7 +60,7 @@ fun Project.shadowJarTask(
     entryPoint: String?,
     classifier: String?,
     name: String = defaultTaskName(platform),
-    excludedPlatforms: Set<String> = defaultExcludedPlatforms(platform),
+    excludedPlatforms: Set<String>? = null,
 ) = shadowJarTask(platform, provider { entryPoint }, name, provider { classifier }, excludedPlatforms)
 
 @Suppress("NAME_SHADOWING")
@@ -64,7 +69,7 @@ fun Project.shadowJarTask(
     entryPoint: Provider<String> = provider { null },
     name: String = defaultTaskName(platform),
     classifier: Provider<String> = provider { null },
-    excludedPlatforms: Set<String> = defaultExcludedPlatforms(platform),
+    excludedPlatforms: Set<String>? = null,
 ): TaskProvider<ShadowJar> {
     val entryPoint = entryPoint.orElse(multiPlatformHelper.fatJarEntryPoint)
     val classifier = classifier.orElse(multiPlatformHelper.fatJarClassifier)
@@ -72,7 +77,10 @@ fun Project.shadowJarTask(
     fun setOfFileSystemLocationsToFileTree(locations: Set<FileSystemLocation>): FileTree =
         locations.map { it.asFile }.map { if (it.isDirectory) fileTree(it) else zipTree(it) }.reduce(FileTree::plus)
 
-    fun fileShouldBeIncluded(file: File): Boolean = excludedPlatforms.none { file.name.endsWith("$it.jar") }
+    // resolved on demand: platforms and inclusions may still be declared after this registration
+    fun actualExcludedPlatforms(): Set<String> = excludedPlatforms ?: defaultExcludedPlatforms(platform)
+
+    fun fileShouldBeIncluded(file: File): Boolean = actualExcludedPlatforms().none { file.name.endsWith("$it.jar") }
     val shadowJar =
         this.maybeRegister<ShadowJar>(name) {
             this.group = "shadow"
@@ -88,7 +96,9 @@ fun Project.shadowJarTask(
                 "configure task ${this.path} for assembling fat jars",
                 platform?.let { " on $it" },
                 entryPoint.orNull?.let { ", with entry point $it" },
-                excludedPlatforms.takeIf { it.isNotEmpty() }?.let { ", excluding dependencies for platforms $it" }
+                actualExcludedPlatforms()
+                    .takeIf { it.isNotEmpty() }
+                    ?.let { ", excluding dependencies for platforms $it" }
                     ?: ", including all dependencies",
             )
         }


### PR DESCRIPTION
Closes #646.
 
### What
 
- `defaultExcludedPlatforms` is no longer evaluated when `shadowJarTask` is called. The `excludedPlatforms` parameter defaults to `null`, meaning "resolve on demand", and the set is computed inside the inclusion predicate, which runs when the `FileCollection` is resolved.
- New `fatJarDefaultExcludedPlatforms` on the helper extension, so that the platform-less fat jar can declare what it leaves out instead of relying on which duplicate the shadow plugin happens to keep.
- `javaFxFatJars()` uses it to exclude `mac-aarch64` from the platform-less jar.

### Why
 
Exclusions were computed against a partially populated configuration, so three of the four per-platform jars carried natives of platforms they should have excluded, and both `fatJarPlatformInclude` declarations were inert. See the issue for measurements.
 
The second point covers a different failure. The `mac` and `mac-aarch64` JavaFX artifacts store their native libraries under identical entry names, so the platform-less jar can only carry one of the two, and which one it carries depends on classpath ordering. Making the choice explicit turns a silent, order-dependent outcome into a declared one.
Downstream, tuProlog/2p-kt ships an IDE jar that fails on Apple Silicon for exactly this reason.
 
### Testing
 
Verified against tuProlog/2p-kt at d2e27d9, which is the downstream project affected by this.
The patch was applied on top of the 5.1.8 tag rather than on `master`, so that the only variable was this change: `master` moved to Kotlin 2.3.21, while 2p-kt pins 2.2.21, and mixing the two fails for unrelated reasons. The three files touched here are identical on both revisions.
 
Native libraries per artifact, from `./gradlew allShadowJars`, before and after:
 
| artifact                 | before                  | after                   |
|--------------------------|-------------------------|-------------------------|
| `redist-win.jar`         | dll=54, so=10, dylib=7  | dll=54, so=0,  dylib=0  |
| `redist-linux.jar`       | dll=0,  so=10, dylib=7  | dll=0,  so=10, dylib=0  |
| `redist-mac.jar`         | dll=0,  so=0,  dylib=7  | dll=0,  so=10, dylib=7  |
| `redist-mac-aarch64.jar` | dll=0,  so=0,  dylib=7  | dll=0,  so=10, dylib=7  |
| `redist.jar`             | dll=54, so=10, dylib=7  | dll=54, so=10, dylib=7  |
 
The Windows artifact went from carrying every platform to carrying only its own, and the same holds for the Linux one. The platform-less jar is unchanged in content, but it now ships the x86-64 dylibs because it is told to, rather than because of classpath ordering.
 
The two macOS artifacts gained the Linux natives. That is the effect of the two `fatJarPlatformInclude("mac", "linux")` declarations becoming effective, and it is the open question raised in the issue: if those two lines were a workaround for this very bug, they can now be removed.
 
The kt-mpp test suite passes unchanged, 171 out of 171. It does not cover this case, because its fixture populates `fatJarPlatforms` before the plugin registers the tasks, whereas downstream projects declare platforms afterwards, from the build script. A regression test built around the latter would be a sensible addition, and I am happy to write one.
 
### Compatibility
 
`excludedPlatforms` changes from `Set<String>` to `Set<String>?`. Callers passing a set, and callers omitting the argument, are unaffected at the source level.